### PR TITLE
v1.1.0: new features; small bug fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
 
   docs:
     name: Documentation
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: read
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PhyloPlots"
 uuid = "c0d5b6db-e3fc-52bc-a87d-1d050989ed3b"
 license = "MIT"
-version = "2.0.1"
+version = "2.1.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![PkgEval](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/P/PhyloPlots.svg)](https://JuliaCI.github.io/NanosoldierReports/pkgeval_badges/report.html)
+[![Downloads](https://img.shields.io/badge/dynamic/json?url=http://juliapkgstats.com/api/v1/monthly_downloads/PhyloPlots&query=total_requests&suffix=/month&label=Downloads)](https://juliapkgstats.com/pkg/PhyloPlots)
 
 ## overview
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliaphylo.github.io/PhyloPlots.jl/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaphylo.github.io/PhyloPlots.jl/dev)
-[![Build status](https://github.com/juliaphylo/PhyloPlots.jl/workflows/CI/badge.svg?branch=master)](https://github.com/juliaphylo/PhyloPlots.jl/actions/workflows/ci.yml)
+[![Build status](https://github.com/juliaphylo/PhyloPlots.jl/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/juliaphylo/PhyloPlots.jl/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/juliaphylo/PhyloPlots.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/juliaphylo/PhyloPlots.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,4 +38,5 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaPhylo/PhyloPlots.jl.git",
     push_preview = true,
+    devbranch = "master",
 )

--- a/docs/src/man/adding_data.md
+++ b/docs/src/man/adding_data.md
@@ -52,7 +52,7 @@ R"par"(mar=[.1,.1,.1,.1]) # hide
 net = readnewick("(A,((B,#H1),(C,(D)#H1)));") # hide
 plot(net, edgelabel=DataFrame(number = [1,2],
                               label = ["edge number 1", "edge # 2"]),
-          edgelabelcolor="orangered", edgecex=[0.9,1.1]);
+     edgelabelcolor="orangered", edgecex=[0.9,1.1], edgelabeladj=[.5,-.3]);
 R"dev.off()" # hide
 nothing # hide
 ```

--- a/docs/src/man/better_edges.md
+++ b/docs/src/man/better_edges.md
@@ -113,12 +113,40 @@ using RCall # to send any command to R, to modify the plot
 R"par"(mar=[.1,.1,.1,.1]); R"layout"([1 2]);
 plot(net1, showedgenumber=true);
 R"mtext"("edge numbers, used\nas keys in edgewidth", side=1, line=-1);
-log_populationsize = Dict(e.number => log10(1_000) for e in net1.edge); # pop size on log scale
-log_populationsize[9] = log10(100_000); # larger populations on edges 9 and 1
-log_populationsize[1] = log10(100_000);
+# below: population sizes on the log scale
+log_populationsize = Dict(e.number => log10(1_000) for e in net1.edge);
+log_populationsize[9] = log10(100_000); # larger populations on edge 9
+log_populationsize[1] = log10(100_000); #                and on edge 1
 log_populationsize
 plot(net1, edgewidth=log_populationsize);
 R"dev.off()"; # hide
 nothing # hide
 ```
 ![example5](../assets/figures/edge_len_example5.svg)
+
+## Customization
+
+Check out the list of [`plot`](@ref) options.
+
+In the example below,
+we first highlight in orange the edges on the 2 paths from the root to C.
+Then we change the type of the minor edge (to hide it).
+
+```@repl better_edges
+ecols = Dict(i => "black" for i in 1:9); # make all black
+for i in [9,8,6,5, 4,3] # except for edges ancestral to C
+  ecols[i] = "orangered"
+end
+ecols
+```
+```@example better_edges
+R"svg"(figname("edge_len_example6.svg"), width=6, height=3) # hide
+R"par"(mar=[.1,.1,.1,.1]); R"layout"([1 2]); # hide
+plot(net1, edgecolor=ecols, defaultedgecolor="grey80", minorlinetype="solid");
+plot(net1, style=:majortree, majorhybridedgecolor="red",
+     minorlinetype="blank"); # make minor edges (arrows) of type 'blank'
+R"mtext"("minor hybrid edge is\nhidden: 'blank' type", side=1, line=-1); # hide
+R"dev.off()"; # hide
+nothing # hide
+```
+![example6](../assets/figures/edge_len_example6.svg)

--- a/src/phylonetworksPlots.jl
+++ b/src/phylonetworksPlots.jl
@@ -332,7 +332,7 @@ function prepare_nodedataframe(
 )
     nrows = (shownodenumber || shownodename || labelnodes ? net.numnodes : net.numtaxa)
     ndf = DataFrame(:name => Vector{String}(undef,nrows),
-        :num => Vector{String}(undef,nrows), :lab => Vector{String}(undef,nrows),
+        :num => Vector{String}(undef,nrows), :lab => fill(""::String,nrows),
         :lea => Vector{Bool}(  undef,nrows), :x => Vector{Float64}( undef,nrows),
         :y => Vector{Float64}( undef,nrows), copycols=false)
     j=1
@@ -346,7 +346,7 @@ function prepare_nodedataframe(
             (nonmissingtype(eltype(nodelabel[!,2])) <: AbstractFloat ?
               @sprintf("%0.3g",nodelabel[jn,2]) : string(nodelabel[jn,2])))
         end
-        ndf[j,:lea] = net.node[i].leaf # use this later to remove H? labels
+        ndf[j,:lea] = net.node[i].leaf
         ndf[j,:y] = node_y[i]
         ndf[j,:x] = node_x[i]
         j += 1
@@ -388,7 +388,7 @@ function prepare_edgedataframe(
     nrows = net.numedges
     edf = DataFrame(:len => Vector{String}(undef,nrows),
         :gam => Vector{String}(undef,nrows), :num => Vector{String}(undef,nrows),
-        :lab => Vector{String}(undef,nrows), :hyb => Vector{Bool}(undef,nrows),
+        :lab => fill(""::String,nrows),      :hyb => Vector{Bool}(undef,nrows),
         :min => Vector{Bool}(  undef,nrows), :x => Vector{Float64}(undef,nrows),
         :y  => Vector{Float64}(undef,nrows), copycols=false)
     labeledges = size(edgelabel,1)>0

--- a/src/plotRCall.jl
+++ b/src/plotRCall.jl
@@ -17,6 +17,9 @@ the right, using R graphics. Optional arguments are listed below.
 - `arrowlen`: the length of the arrow tips in the full tree style.
   The default is 0.1 if `style = :fulltree`,
   and 0 if `style = :majortree` (making the arrows appear as segments).
+- `minorlinetype`: type of lines used for minor edges, represented by arrows.
+  Default is "solid" under the major-tree style, and "longdash" under the
+  full tree style.
 - `edgewidth=1`: width of horizontal (not diagonal) edges. To vary them,
   use a dictionary to map the number of each edge to its desired width.
 - `xlim`, `ylim`: array of 2 values, to determine the axes limits.
@@ -130,6 +133,7 @@ function plot(
     edgecex = 1,
     style::Symbol=:fulltree,
     arrowlen::Real=(style==:majortree ? 0 : 0.1),
+    minorlinetype = nothing,
     edgewidth = 1,
     edgenumbercolor = "grey", # don't limit the type because R accepts many types
     edgelabelcolor = "black", # and these colors are used as is
@@ -209,7 +213,9 @@ function plot(
       end
     end
     # this makes the arrows dashed if :fulltree is used
-    arrowstyle = style==:majortree ? "solid" : "longdash"
+    if isnothing(minorlinetype)
+        minorlinetype = (style==:majortree ? "solid" : "longdash")
+    end
 
     if !(style in [:fulltree, :majortree])
       @warn "Style $style is unknown. Defaulted to :fulltree."
@@ -223,7 +229,7 @@ function plot(
     """
     R"segments"(edge_xB, edge_yB, edge_xE, edge_yE, col=eCol, lwd=edgewidth_vec)
     R"arrows"(hybridedge_xB, hybridedge_yB, hybridedge_xE, hybridedge_yE,
-              length=arrowlen, angle=20, col=hybmincol_vec, lty=arrowstyle,
+              length=arrowlen, angle=20, col=hybmincol_vec, lty=minorlinetype,
               lwd=hybridedgewidth_vec)
     R"segments"(node_x, node_yB, node_x, node_yE, col=defaultedgecolor)
     if showtiplabel

--- a/src/plotRCall.jl
+++ b/src/plotRCall.jl
@@ -30,7 +30,7 @@ the right, using R graphics. Optional arguments are listed below.
 ## nodes & edges annotations:
 
 - `shownodelabel = false`: if true, internal nodes are labelled with their names.
-  Useful for hybrid nodes, which do have tags like 'H1'.
+  Useful for hybrid nodes, which have labels such as "H1".
 - `shownodenumber = false`: if true, nodes are labelled with the number used internally.
 - `showedgenumber = false`: if true, edges are labelled with the number used internally.
 - `showedgelength = false`: if true, edges are labelled with their length (above).
@@ -59,13 +59,14 @@ the right, using R graphics. Optional arguments are listed below.
 - `edgelabelcolor = "black"`: color for labels in the `edgelabel` data frame.
 - `nodelabelcolor = "black"`: color for labels in the `nodelabel` data frame.
 
-Output the following named tuple, that can be used for downstream plot annotations
+Output the following named tuple, that can be used for downstream annotations
 with RCall:
 
 ```
 (xmin, xmax, ymin, ymax,
- node_x,    node_y,    node_y_lo, node_y_hi,
- edge_x_lo, edge_x_hi, edge_y_lo, edge_y_hi,
+ node_x,     node_y,     node_y_lo, node_y_hi,
+ edge_x_lo,  edge_x_hi,  edge_y_lo,  edge_y_hi,
+ arrow_x_lo, arrow_x_hi, arrow_y_lo, arrow_y_hi,
  node_data, edge_data)
 ```
 
@@ -75,14 +76,25 @@ with RCall:
 4. `:ymax`: maximum y value of the plot
 5. `:node_x`: x values of the nodes in net.node in their respective order
 6. `:node_y`: y values of the nodes
-7. `:node_y_lo`: y value of the beginning of the vertical bar representing the clade at each node
+7. `:node_y_lo`: y value of the beginning of the vertical bar representing the
+    clade at each node
 8. `:node_y_hi`: y value of the end of the vertical bar
-9. `:edge_x_lo`: x value of the beginning of the edges in `net.edge` in their respective order
+9. `:edge_x_lo`: x value of the beginning of the edges in `net.edge` in their
+    respective order. An edge (or branch) in the network is represented by 2
+    segments if it is a minor edge under the `:fulltree` style.
+    `:edge_*` give the coordinates of the first (horizontal) segment for these
+    minor edges, and the coordinates of the unique (horizontal) segment for
+    major edges (tree of major hybrid edges).
 10. `:edge_x_hi`: x value of the end of the edges
 11. `:edge_y_lo`: y value of the beginning of the edges
 12. `:edge_y_hi`: y value of the end of the edges
-13. `:node_data`: node data frame: see section [Adding labels](@ref) for more
-14. `:edge_data`: edge data frame
+13. `:arrow_x_lo`: x value for the beginning of the arrows, for minor hybrid
+     edges, listed in the same order as in `filter(e -> !e.ismajor, net.edge)`.
+14. `:arrow_x_hi`: same, but for the end of arrows
+15. `:arrow_y_lo`: y values for the beginning of arrows
+16. `:arrow_y_hi`: same, but for the end of arrows
+17. `:node_data`: node data frame: see section [Adding labels](@ref) for more
+18. `:edge_data`: edge data frame
 
 Note that `plot` actually modifies some (minor) attributes of the network,
 as it calls `PhyloNetworks.directedges!` and `PhyloNetworks.preorder!`
@@ -257,5 +269,7 @@ function plot(
       node_y_lo=node_yB, node_y_hi=node_yE,
       edge_x_lo=edge_xB, edge_x_hi=edge_xE,
       edge_y_lo=edge_yB, edge_y_hi=edge_yE,
+      arrow_x_lo=hybridedge_xB, arrow_x_hi=hybridedge_xE,
+      arrow_y_lo=hybridedge_yB, arrow_y_hi=hybridedge_yE,
       node_data=ndf, edge_data=edf)
 end

--- a/src/plotRCall.jl
+++ b/src/plotRCall.jl
@@ -171,13 +171,11 @@ function plot(
     end
     leaves = [n.leaf for n in net.node]
     if isa(edgecolor, AbstractDict) # then ignore {maj|min}orhybridedgecolor
-      ectype = valtype(edgecolor)
-      defaultedgecolor = (isnothing(defaultedgecolor) ?
-        ectype("black") : ectype(defaultedgecolor) )
-      eCol = Vector{ectype}(undef,length(net.edge))
-      hybmincol_vec = Vector{ectype}()
+      defaultedgecolor = (isnothing(defaultedgecolor) ? "black" : string(defaultedgecolor) )
+      eCol = Vector{String}(undef,length(net.edge))
+      hybmincol_vec = Vector{String}()
       for (ie,ee) in enumerate(net.edge)
-        ec = get(edgecolor, ee.number, defaultedgecolor)
+        ec = string(get(edgecolor, ee.number, defaultedgecolor))
         eCol[ie] = ec
         if !ee.ismajor
           push!(hybmincol_vec, ec)

--- a/test/test_plotRCall.jl
+++ b/test/test_plotRCall.jl
@@ -1,4 +1,4 @@
-@testset "RCall-based plot Test" begin
+@testset "RCall-based plots" begin
   # testing for absence of errors, not for correctness
 
   # network rooted at a leaf: test for no error in warning message

--- a/test/test_plotRCall.jl
+++ b/test/test_plotRCall.jl
@@ -41,7 +41,11 @@
   @test res[:arrow_x_hi] == [5,4]
   @test res[:arrow_y_lo] == [2.9,1.5]
   @test res[:arrow_y_hi] == [3,  2.9]
-  res = (@test_logs plot(net2, preorder=false))
+  @test res[:node_data].lab[[1,3]] == ["",""]
+  @test res[:edge_data][[2,5],2:4] == DataFrame(
+      gam=["0.2","1"], num=["2","5"], lab=["",""])
+  res = (@test_logs plot(net2, preorder=false,
+    edgelabel=DataFrame(num=[2,6], annotate=[85.0001,90])))
   @test res[:node_y_lo] == [5,5,1,2,3,2,6,5,3,  1]
   @test res[:node_y_hi] == [5,5,1,2,3,4,6,6,5.5,4.25]
   @test res[:edge_x_lo] == [5,4,1,3,3,3,2,4,4,2,1]
@@ -52,4 +56,7 @@
   @test res[:arrow_x_hi] == res[:arrow_x_lo] # bc :fulltree style
   @test res[:arrow_y_lo] == [1,4]
   @test res[:arrow_y_hi] == [5,1]
+  @test res[:node_data].lab[[1,3]] == ["",""]
+  @test res[:edge_data][[2,5],2:4] == DataFrame(
+      gam=["0.2","1"], num=["2","5"], lab=["85",""])
 end

--- a/test/test_plotRCall.jl
+++ b/test/test_plotRCall.jl
@@ -29,9 +29,27 @@
   res = (@test_logs plot(net2, style=:majortree))
   @test keys(res) == (:xmin, :xmax, :ymin, :ymax, :node_x, :node_y,
     :node_y_lo, :node_y_hi, :edge_x_lo, :edge_x_hi, :edge_y_lo, :edge_y_hi,
+    :arrow_x_lo, :arrow_x_hi, :arrow_y_lo, :arrow_y_hi,
     :node_data, :edge_data)
-
-  # plot based on RCall and ape:
-  tre = readnewick("(((((((1,2),3),4),5),(6,7)),(8,9)),10);");
-  # fixit: plot(tre, :ape)
+  @test res[:node_y_lo] == [3,3,2.9,1,2,1,4,3,1.5,2.5]
+  @test res[:node_y_hi] == [3,3,2.9,1,2,2,4,4,3.5,2.9]
+  @test res[:edge_x_lo] == [5,4,  1,  3,3,3,  2,  4,4,2,  1]
+  @test res[:edge_x_hi] == [6,4,  4,  6,6,3,  3,  5,6,4,  2]
+  @test res[:edge_y_lo] == [3,2.9,2.9,1,2,1.5,1.5,3,4,3.5,2.5]
+  @test res[:edge_y_hi] == res[:edge_y_lo]
+  @test res[:arrow_x_lo] == [4,3]
+  @test res[:arrow_x_hi] == [5,4]
+  @test res[:arrow_y_lo] == [2.9,1.5]
+  @test res[:arrow_y_hi] == [3,  2.9]
+  res = (@test_logs plot(net2, preorder=false))
+  @test res[:node_y_lo] == [5,5,1,2,3,2,6,5,3,  1]
+  @test res[:node_y_hi] == [5,5,1,2,3,4,6,6,5.5,4.25]
+  @test res[:edge_x_lo] == [5,4,1,3,3,3,2,4,4,2,1]
+  @test res[:edge_x_hi] == [6,5,4,6,6,4,3,5,6,4,2]
+  @test res[:edge_y_lo] == [5,1,1,2,3,4,3,5,6,5.5,4.25]
+  @test res[:edge_y_hi] == res[:edge_y_lo]
+  @test res[:arrow_x_lo] == [5,4]
+  @test res[:arrow_x_hi] == res[:arrow_x_lo] # bc :fulltree style
+  @test res[:arrow_y_lo] == [1,4]
+  @test res[:arrow_y_hi] == [5,1]
 end

--- a/test/test_plotRCall.jl
+++ b/test/test_plotRCall.jl
@@ -26,7 +26,9 @@
 
   # coverage for the nomajorchild
   net2 = readnewick("((((B)#H1)#H2,((D,C,#H2)S1,(#H1:::.8,A)S2)S3)S4);")
-  res = (@test_logs plot(net2, style=:majortree))
+  ecd = Dict(1 => SubString("grey50"), 2 => 2, 3 => "violet") # color 2 = red in R
+  res = (@test_logs plot(net2, style=:majortree, edgecolor=ecd,
+    defaultedgecolor="turquoise"))
   @test keys(res) == (:xmin, :xmax, :ymin, :ymax, :node_x, :node_y,
     :node_y_lo, :node_y_hi, :edge_x_lo, :edge_x_hi, :edge_y_lo, :edge_y_hi,
     :arrow_x_lo, :arrow_x_hi, :arrow_y_lo, :arrow_y_hi,

--- a/test/test_plotRCall.jl
+++ b/test/test_plotRCall.jl
@@ -12,7 +12,7 @@
   @test_logs (:warn, "At least one non-missing edge length: plotting any missing length as 1.0") plot(net, useedgelength=true);
   @test_logs plot(net, showtiplabel=false);
   @test_logs plot(net, shownodenumber=true, shownodelabel=true);
-  @test_logs plot(net, tipoffset=1, showgamma=true);
+  @test_logs plot(net, tipoffset=1, showgamma=true, minorlinetype=3); # 3=dotted
   @test_logs plot(net, showedgelength=true, showedgenumber=true);
   @test_logs plot(net, edgecolor="tomato4", minorhybridedgecolor="skyblue",
           majorhybridedgecolor="tan");


### PR DESCRIPTION
new features:
- The `NamedTuple` returned by `plot` now includes the coordinates of arrows.
  For logic, these extra slots are not placed at the end, which technically causes an API change (items previously 13 & 14 are now in positions 17 & 18).
  But this change is considered minor enough to *not* warrant a change in the package major version, because: (1) the plot itself if the output of interest, not the returned NamedTuple (2) this output NamedTuple should be accessed by names, and there is *no* API change when doing so.
- new option `preorder`: to make it possible to avoid re-directing edges and re-calculating node pre-ordering
- new options: `edgelabeladj`, `nodelabeladj`, `defaultedgecolor`
- new option: `edgecolor` as a dictionary

bug fixes
- `edgewidth`s were not used for minor hybrid edges (arrows); they now are
- output node and edge data frame without `undef` values. Previously, their `lab` column had undefined values, and subsetting the data frame or its `lab` column lead to: `ERROR: UndefRefError: access to undefined reference`. Associated tests were added.
